### PR TITLE
Add runtime options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ BIGBLUEBOT_HOST=https://your.bigbluebutton.server
 ```
  - [optional] room name or meetingID
 ```
-BIGBLUEBOT_ROOM=Demo Meeting
+BIGBLUEBOT_ROOM=yourbigbluebuttonroomidentifier
 ```
 If you would like the bots to join an existing room, you may fill
 out the password variables and use the `meetingID` value as `BIGBLUEBOT_ROOM`
@@ -81,9 +81,9 @@ Join audio with microphone
 ```js
 const bigbluebot = require('bigbluebot');
 
-let actions = async page => {
+const actions = async page => {
   await bigbluebot.audio.modal.microphone(page);
-}
+};
 
 bigbluebot.run(actions);
 ```
@@ -93,9 +93,9 @@ Join audio as a listener
 ```js
 const bigbluebot = require('bigbluebot');
 
-let actions = async page => {
+const actions = async page => {
   await bigbluebot.audio.modal.listen(page);
-}
+};
 
 bigbluebot.run(actions);
 ```
@@ -105,9 +105,9 @@ Join video
 ```js
 const bigbluebot = require('bigbluebot');
 
-let actions = async page => {
+const actions = async page => {
   await bigbluebot.video.join(page);
-}
+};
 
 bigbluebot.run(actions);
 ```
@@ -117,11 +117,38 @@ Write in chat
 ```js
 const bigbluebot = require('bigbluebot');
 
-let actions = async page => {
+const actions = async page => {
   await bigbluebot.chat.send(page);
-}
+};
 
 bigbluebot.run(actions);
+```
+
+#### Runtime options
+
+You can pass options as a run parameter
+
+```js
+const bigbluebot = require('bigbluebot');
+
+const actions = async page => {
+  await bigbluebot.audio.modal.microphone(page);
+  await bigbluebot.video.join(page);
+  await bigbluebot.chat.send(page);
+};
+
+const options = {
+  host: 'https://your.bigbluebutton.server',
+  secret: 'yourbigbluebuttonsecret',
+  room: 'yourbigbluebuttonroomidentifier',
+  password: {
+    moderator: 'yourmoderatorpassword',
+    attendee: 'yourattendeepassword',
+  },
+  moderator: true OR false,
+};
+
+bigbluebot.run(actions, options);
 ```
 
 ### Run your script

--- a/example.js
+++ b/example.js
@@ -1,15 +1,9 @@
-/**
- * @name Example
- *
- * @desc Dispatch an HTML5 bot script
- */
+const bigbluebot = require('./index.js');
 
-const bigbluebot = require('./index.js')
+const actions = async page => {
+  await bigbluebot.audio.modal.microphone(page);
+  await bigbluebot.video.join(page);
+  await bigbluebot.chat.send(page);
+};
 
-let actions = async page => {
-  await bigbluebot.audio.modal.microphone(page)
-  await bigbluebot.video.join(page)
-  await bigbluebot.chat.send(page)
-}
-
-bigbluebot.run(actions)
+bigbluebot.run(actions);

--- a/lib/api.js
+++ b/lib/api.js
@@ -23,56 +23,56 @@ const buildQuery = params => {
   return query;
 };
 
-const getURL = (action, params) => {
+const getURL = (action, params, options) => {
   const query = buildQuery(params);
-  const checksum = calculateChecksum(action, query);
-  const host = config.url.host;
+  const checksum = calculateChecksum(action, query, options);
+  const host = options.host || config.url.host;
   const api = config.api.path;
   const url = `${host}/${api}/${action}?${query}&checksum=${checksum}`;
 
   return url;
 };
 
-const calculateChecksum = (action, query) => {
-  const { secret } = config.api;
+const calculateChecksum = (action, query, options) => {
+  const secret = options.secret || config.api.secret;
   const checksum = sha1(action + query + secret);
 
   return checksum
 };
 
-const getCreateURL = () => {
+const getCreateURL = (options) => {
   const params = {
-    meetingID: config.url.meeting.name,
+    meetingID: options.room || config.url.meeting.name,
     record: true,
-    moderatorPW: config.api.password.moderator,
-    attendeePW: config.api.password.attendee,
+    moderatorPW: options.password.moderator || config.api.password.moderator,
+    attendeePW: options.password.attendee || config.api.password.attendee,
   };
 
-  return getURL('create', params);
+  return getURL('create', params, options);
 };
 
-const getEndURL = () => {
+const getEndURL = (options) => {
   const params = {
-    meetingID: config.url.meeting.name,
-    password: config.api.password.moderator,
+    meetingID: options.room || config.url.meeting.name,
+    password: options.password.moderator || config.api.password.moderator,
   };
 
-  return getURL('end', params);
+  return getURL('end', params, options);
 };
 
-const getJoinURL = username => {
-  let password = config.api.password.attendee;
-  if (config.url.moderator.value) {
-    password = config.api.password.moderator;
+const getJoinURL = (username, options) => {
+  let password = options.password.attendee || config.api.password.attendee;
+  if (options.moderator !== undefined ? options.moderator : config.url.moderator.value) {
+    password = options.password.moderator || config.api.password.moderator;
   }
 
   const params = {
-    meetingID: config.url.meeting.name,
+    meetingID: options.room || config.url.meeting.name,
     fullName: username,
     password: password,
   };
 
-  return getURL('join', params);
+  return getURL('join', params, options);
 };
 
 module.exports = {

--- a/lib/run.js
+++ b/lib/run.js
@@ -5,33 +5,38 @@ const logger = require('./logger');
 
 const { api, bot, url, misc } = conf.config;
 
-const dependencies = () => {
-  if (!url.host) {
+const dependencies = (options) => {
+  if (!url.host && !options.host) {
     logger.error('BigBlueButton host is not defined');
     return false;
   }
   return true;
 };
 
-const run = async actions => {
+const run = async (actions, options = {}) => {
   // Check for dependencies
-  if (!dependencies()) return null;
+  if (!dependencies(options)) return null;
 
   // Print some basic settings
   logger.info(`Bots: ${pool.size * pool.population}`);
   logger.info(`Life: ${bot.life / 1000} seconds`);
 
+  // Assume a private room if the server secret was configured
+  const private = api.secret || options.secret;
+
   // Create the meeting if not created yet
-  if (api.secret) {
-    const success = await util.create();
+  if (private) {
+    const success = await util.create(options);
     if (!success) return null;
   }
 
   // Fetch the UI labels from locale
-  const locale = await util.locale();
+  const locale = await util.locale(options);
 
   let browsers = [];
   for (let i = 0; i < pool.size; i++) {
+    logger.debug(`Opening browser`);
+
     // Open a new browser process
     browsers.push(pool.browsers.acquire().then(async browser => {
       let promises = [];
@@ -41,7 +46,7 @@ const run = async actions => {
 
         // Dispatch a new bot
         promises.push(browser.newPage().then(async page => {
-          username = await util.join(page, locale);
+          username = await util.join(page, locale, options);
           page.bigbluebot = { username, locale };
           await actions(page);
           await page.waitForTimeout(bot.life);
@@ -75,7 +80,7 @@ const run = async actions => {
   }
 
   await Promise.all(browsers).finally(async () => {
-    if (api.secret && misc.meeting.end) await util.end();
+    if (private && misc.meeting.end) await util.end(options);
   });
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -11,22 +11,22 @@ const delay = async time => new Promise(resolve => setTimeout(resolve, time));
 const timestamp = () => Math.floor(new Date() / 1000);
 const random = collection => collection[Math.floor(Math.random() * collection.length)];
 
-const getDemoJoinURL = username => {
+const getDemoJoinURL = (username, options) => {
   const user = `${config.url.user.param}=${encodeURI(username)}`;
-  const moderator = `${config.url.moderator.param}=${config.url.moderator.value}`;
-  const meeting = `${config.url.meeting.param}=${encodeURI(config.url.meeting.name)}`;
+  const moderator = `${config.url.moderator.param}=${options.moderator !== undefined ? options.moderator : config.url.moderator.value}`;
+  const meeting = `${config.url.meeting.param}=${encodeURI(options.room || config.url.meeting.name)}`;
 
-  return `${config.url.host}/${config.url.demo}&${user}&${moderator}&${meeting}`;
+  return `${options.host || config.url.host}/${config.url.demo}&${user}&${moderator}&${meeting}`;
 };
 
-const getAPIJoinURL = username => {
-  return api.getJoinURL(username);
+const getAPIJoinURL = (username, options) => {
+  return api.getJoinURL(username, options);
 };
 
-const url = username => {
-  if (config.api.secret) return getAPIJoinURL(username);
+const url = (username, options) => {
+  if (config.api.secret || options.secret) return getAPIJoinURL(username, options);
 
-  return getDemoJoinURL(username);
+  return getDemoJoinURL(username, options);
 };
 
 const once = async (page, event, callback) => {
@@ -118,12 +118,12 @@ module.exports = {
   delay: delay,
   random: random,
   generateText: generateText,
-  join: async (page, locale) => {
+  join: async (page, locale, options) => {
     const username = generateUsername();
-    logger.info(`${username}: join ${config.url.host} at ${config.url.meeting.name}`);
+    logger.info(`${username}: join ${options.host || config.url.host} at ${options.room || config.url.meeting.name}`);
     const { width, height } = config.browser.window;
     await page.setViewport({ width, height });
-    await page.goto(url(username));
+    await page.goto(url(username, options));
     const selector = translate(locale, conf.label.main.options.button);
     await page.waitForSelector(selector, { timeout: timeout.selector });
     logger.debug(`${username}: notice ${selector}`);
@@ -131,15 +131,15 @@ module.exports = {
 
     return username;
   },
-  create: async () => {
+  create: async (options) => {
     logger.info('Creating meeting');
-    const data = await call(api.getCreateURL());
+    const data = await call(api.getCreateURL(options));
 
     return data !== null;
   },
-  end: async () => {
+  end: async (options) => {
     logger.info('Ending meeting');
-    const data = await call(api.getEndURL());
+    const data = await call(api.getEndURL(options));
 
     return data !== null;
   },
@@ -215,10 +215,11 @@ module.exports = {
 
     return hidden;
   },
-  locale: async () => {
+  locale: async (options) => {
     const { lang } = config.browser;
     logger.info(`Fetching ${lang} locale`);
-    const url = `${config.url.host}/${config.url.locale}=${lang}`;
+    const host = options.host || config.url.host;
+    const url = `${host}/${config.url.locale}=${lang}`;
     let locale;
     await axios.get(url).then(response => {
       const { messages } = response.data;


### PR DESCRIPTION
Some basic configurations can now be passed as run parameter. They are all
optional and, if set, wil take precedence over config and environment variables.

This should improve the flexibility, for instance, when the test case requires
bots with different roles/rooms/servers.