### PR TITLE
Adding version parameter on .env and conf.js files

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,9 @@
 # <string> BigBlueButton hostname.
 BIGBLUEBOT_HOST=
 
+# <string> Running BigBlueButton server version.
+BIGBLUEBOT_VERSION=
+
 # <string> Room name or meetingID the bot should join. Defaults to "Demo Meeting"
 # BIGBLUEBOT_ROOM=
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ At the `.env` file you just copied, set:
 ```
 BIGBLUEBOT_HOST=https://your.bigbluebutton.server
 ```
+ - your BigBlueButton server running version (currently 2.2 or 2.3)
+```
+BIGBLUEBOT_VERSION=2.2
+```
  - [optional] room name or meetingID
 ```
 BIGBLUEBOT_ROOM=yourbigbluebuttonroomidentifier

--- a/lib/conf.js
+++ b/lib/conf.js
@@ -7,6 +7,7 @@ let custom = config;
 
 const {
   BIGBLUEBOT_HOST,
+  BIGBLUEBOT_VERSION,
   BIGBLUEBOT_SECRET,
   BIGBLUEBOT_ROOM,
   BIGBLUEBOT_ATTENDEE_PW,
@@ -24,6 +25,7 @@ const {
 } = process.env;
 
 if (BIGBLUEBOT_HOST) custom.url.host = BIGBLUEBOT_HOST;
+if (BIGBLUEBOT_VERSION) custom.url.version = BIGBLUEBOT_VERSION;
 if (BIGBLUEBOT_ROOM) custom.url.meeting.name = BIGBLUEBOT_ROOM;
 
 if (BIGBLUEBOT_SECRET) custom.api.secret = BIGBLUEBOT_SECRET;


### PR DESCRIPTION
I didn't change a lot, but there was an error when using with version 2.3 due to a change on locale messages URL.
The code seems to be already prepared, reading the version from `config.url.version` but there was nowhere to set this. 