### PR TITLE
!chore: drop v2.3 and v2.4 support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ BIGBLUEBOT_HOST=https://your.bigbluebutton.server
 ```
 BIGBLUEBOT_SECRET=yourbigbluebuttonsecret
 ```
-- your BigBlueButton server running version (currently 2.3 or 2.4)
+- your BigBlueButton server running version (currently 2.5)
 ```
-BIGBLUEBOT_VERSION=2.4
+BIGBLUEBOT_VERSION=2.5
 ```
  - [optional] room name or meetingID
 ```

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
   "url": {
     "host": null,
-    "version": "2.4",
+    "version": "2.5",
     "basename": "html5client",
     "user": {
       "param": "username"

--- a/config/config.json
+++ b/config/config.json
@@ -12,7 +12,8 @@
     },
     "meeting": {
       "param": "meetingname",
-      "name": "Demo Meeting"
+      "name": "Demo Meeting",
+      "record": false
     }
   },
   "api": {

--- a/config/config.json
+++ b/config/config.json
@@ -46,7 +46,9 @@
         "min": 1,
         "max": 10
       }
-    }
+    },
+    "audioFile": "",
+    "videoFile": ""
   },
   "content": {
     "whiteboard": {

--- a/lib/api.js
+++ b/lib/api.js
@@ -44,6 +44,8 @@ const getMeetingID = (options) => options.room || config.url.meeting.name;
 
 const getName = (options) => getMeetingID(options);
 
+const getRecord = (options) => options.record || config.url.meeting.record;
+
 const getVersion = (options) => options.version || config.url.version;
 
 const getPassword = (role, options) => {
@@ -72,7 +74,7 @@ const getCreateURL = (options) => {
   const params = {
     meetingID: getMeetingID(options),
     name: getName(options),
-    record: true,
+    record: getRecord(options),
     moderatorPW: getPassword('moderator', options),
     attendeePW: getPassword('attendee', options),
   };

--- a/lib/locales.js
+++ b/lib/locales.js
@@ -74,8 +74,7 @@ module.exports = {
     await fetchLocale(client).then(async response => {
       const version = api.getVersion(options);
       switch (version) {
-        case '2.3':
-        case '2.4':
+        case '2.5':
           const {
             normalizedLocale,
             regionDefaultLocale,

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -10,6 +10,8 @@ const ARGS = [
   `--no-user-gesture-required`,
   `--use-fake-ui-for-media-stream`,
   `--use-fake-device-for-media-stream`,
+  browser.videoFile && `--use-file-for-fake-video-capture=${browser.videoFile}`,
+  browser.audioFile && `--use-file-for-fake-audio-capture=${browser.audioFile}`,
 ];
 
 const factory = {


### PR DESCRIPTION
This PR does 3 things:
- [!chore: drop v2.3 and v2.4 support](https://github.com/mconf/bigbluebot/commit/f78b282275498983bd034ca3021e4970b3f8cdf4)
  > BREAKING CHANGE: add v2.5 support and remove v2.3 and v2.4
- [feat: propagate record param through options](https://github.com/mconf/bigbluebot/commit/c1217c8eab7882ed2d24926791a0d0ed79009ce3)
  > Default record value in config.json is false.

- [feat: add input audio/video file](https://github.com/mconf/bigbluebot/commit/3d5455507ab0691853fcc225c08c5ef63f61c94c)
  > Enables passing audio and/or video files to the browser as mic and webcam
input.
The audio and video file are defined in the config.json and are passed to the
browser via:
	--use-file-for-fake-audio-capture
	--use-file-for-fake-video-capture
The audio file must be an .wav and video must be .y4m file.